### PR TITLE
fix typo in enum.md

### DIFF
--- a/docs/stable/sql/data_types/enum.md
+++ b/docs/stable/sql/data_types/enum.md
@@ -35,7 +35,7 @@ Enums can also be created on the fly during [casting]({% link docs/stable/sql/ex
 SELECT 'some_string'::ENUM ([⟨value_1⟩, ⟨value_2⟩, ...]);
 ```
 
-### Exaples
+### Examples
 
 Creates new user defined type `mood` as an enum:
 


### PR DESCRIPTION
Noticed a typo here while I'm reading the docs https://duckdb.org/docs/stable/sql/data_types/enum#enum-definition